### PR TITLE
Support key rotation

### DIFF
--- a/src/exoscale/itsdangerous.clj
+++ b/src/exoscale/itsdangerous.clj
@@ -50,14 +50,29 @@
     (catch Exception e
       (ex/ex-incorrect! "error while processing token" {::token s} e))))
 
+(defn main-key
+  "Figure out which private-key to use from the config.
+   Support either a single `::private-key` for backward compatibility,
+   or a collection of keys, in which case the first is selected."
+  [{::keys [private-keys private-key]}]
+  (or (first private-keys) private-key))
+
 (defn signature-for
   "Given a supported algorithm (`::hmac-sha1` `::hmac-sha256`), private key, and
    salt, compute the signature of a payload. Yields the signature in Base64."
-  [{::keys [algorithm private-key salt]} payload]
-  (let [sign (hmac/by-algorithm algorithm)]
-    (->> (sign salt private-key)
-         (sign payload)
+  [{::keys [algorithm salt] :as config} payload private-key]
+  (let [signer (hmac/by-algorithm algorithm)]
+    (->> (signer salt private-key)
+         (signer payload)
          (codec/b->b64))))
+
+(defn signatures-for
+  "Yield all possible signatures for a payload, based on the config"
+  [{::keys [algorithm private-keys salt] :as config} payload]
+  (if (empty? private-keys)
+    [(signature-for config payload (::private-key config))]
+    (for [private-key private-keys]
+      (signature-for config payload private-key))))
 
 (defn sign
   "Run the signature process for a payload, yields token as a string.
@@ -65,34 +80,45 @@
    Needs at least `::algorithm`, `::salt`, `::private-key`, and `::payload`.
    `::algorithm`, `::salt`, and `::private-key` are shared knowledge elements,
    to be agreed upon out-of-band, `::payload`, the payload to sign as a string.
+   If `::private-keys` is provided instead of `::private-key`, the first key
+   in the collection is used to sign the payload.
 
    Optionally accepts `::timestamp`, defaulting to the UNIX epoch in seconds."
-  [{::keys [algorithm salt timestamp payload private-key]
-    :or    {algorithm ::hmac-sha1
-            timestamp (epoch)}
-    :as    opts}]
-  (ex/assert-spec-valid ::sign-input opts)
-  (let [to-sign (str (codec/s->b64 payload) "." (codec/int->b64 timestamp))]
-    (str to-sign "." (signature-for opts to-sign))))
+  ([{::keys [algorithm salt timestamp payload]
+     :or    {algorithm ::hmac-sha1
+             timestamp (epoch)}
+     :as    config}]
+   (ex/assert-spec-valid ::sign-input config)
+   (let [to-sign (str (codec/s->b64 payload) "." (codec/int->b64 timestamp))]
+     (str to-sign "." (signature-for config to-sign (main-key config)))))
+  ([config payload]
+   (sign (assoc config ::payload payload)))
+  ([config payload timestamp]
+   (sign (assoc config ::payload payload ::timestamp timestamp))))
 
 (defn verify
   "Run verification on a token, throwing if the signature is invalid
    or if the token's validity has expired. Yields the payload upon success.
 
-   Needs at least `::algorithm`, `::salt`, `::private-key`, and `::payload`.
+   Needs at least `::algorithm`, `::salt`, `::private-key`, and `::token`.
   `::algorithm`, `::salt`, and `::private-key` are shared knowledge elements,
    to be agreed upon out-of-band, `::token`, the token to verify.
 
    Optionally accepts `::max-age`, in which case token validity in time will be
    checked."
-  [{::keys [token algorithm salt max-age private-key]
-    :or    {algorithm ::hmac-sha1}
-    :as    opts}]
-  (ex/assert-spec-valid ::verify-input opts)
-  (let [{::keys [to-sign payload timestamp signature]} (parse-token token)]
-    (when-not (comp/=== signature (signature-for opts to-sign))
-      (ex/ex-forbidden! "invalid signature"))
-    (when (and (some? max-age)
-               (< max-age (- (epoch) timestamp)))
-      (ex/ex-forbidden! "token validity expired"))
-    payload))
+  ([{::keys [token algorithm salt max-age private-key]
+     :or    {algorithm ::hmac-sha1}
+     :as    config}]
+   (ex/assert-spec-valid ::verify-input config)
+   (let [{::keys [to-sign payload timestamp signature]} (parse-token token)]
+     (when-not (some (partial comp/=== signature)
+                     (signatures-for config to-sign))
+       (ex/ex-forbidden! "invalid signature"))
+     (when (and (some? max-age)
+                (< max-age (- (epoch) timestamp)))
+       (ex/ex-forbidden! "token validity expired"))
+     payload))
+  ([config token]
+   (verify (assoc config ::token token)))
+  ([config token max-age]
+   (verify (assoc config ::token token ::max-age max-age))))

--- a/test/exoscale/itsdangerous/instrument.clj
+++ b/test/exoscale/itsdangerous/instrument.clj
@@ -9,8 +9,9 @@
             exoscale.itsdangerous.spec))
 
 (def parse-token-overrides
-  {::danger/token (constantly
-                   (gen/fmap danger/sign (s/gen ::danger/sign-input)))})
+  {::danger/token #(gen/fmap
+                    (partial apply danger/sign)
+                    (s/gen (s/tuple ::danger/config ::danger/payload)))})
 
 (deftest parse-token-test
   (is
@@ -25,6 +26,30 @@
   (is
    (empty?
     (for [res (stest/check `danger/signature-for)
+          :let [abbrev (stest/abbrev-result res)]
+          :when (some? (:failure abbrev))]
+      abbrev))))
+
+(deftest signatures-for-test
+  (is
+   (empty?
+    (for [res (stest/check `danger/signatures-for)
+          :let [abbrev (stest/abbrev-result res)]
+          :when (some? (:failure abbrev))]
+      abbrev))))
+
+(deftest main-key-test
+  (is
+   (empty?
+    (for [res (stest/check `danger/main-key)
+          :let [abbrev (stest/abbrev-result res)]
+          :when (some? (:failure abbrev))]
+      abbrev))))
+
+(deftest epoch-test
+  (is
+   (empty?
+    (for [res (stest/check `danger/epoch)
           :let [abbrev (stest/abbrev-result res)]
           :when (some? (:failure abbrev))]
       abbrev))))

--- a/test/exoscale/itsdangerous/property_testing.clj
+++ b/test/exoscale/itsdangerous/property_testing.clj
@@ -11,76 +11,63 @@
 (stest/instrument `danger/verify)
 (stest/instrument `danger/parse-token)
 (stest/instrument `danger/signature-for)
+(stest/instrument `danger/main-key)
 
 (defspec roundtrip-sign-to-verify
   10000
   (prop/for-all
-   [input (s/gen (s/keys :req [::danger/algorithm ::danger/payload
-                               ::danger/private-key ::danger/salt]))]
-   (let [token (danger/sign input)]
-     (= (::danger/payload input)
-        (danger/verify (-> input
-                           (dissoc ::danger/payload)
-                           (assoc ::danger/token token)))))))
+   [config (s/gen ::danger/config)
+    payload (s/gen ::danger/payload)]
+   (let [token (danger/sign config payload)]
+     (= payload (danger/verify config token)))))
 
 (defspec token-validity-is-enforced
   10000
   (prop/for-all
-   [input (s/gen (s/keys :req [::danger/algorithm ::danger/payload
-                               ::danger/private-key ::danger/salt]))]
-   (let [token (danger/sign (assoc input ::danger/timestamp 0))]
+   [config  (s/gen ::danger/config)
+    payload (s/gen ::danger/payload)]
+   (let [token (danger/sign config payload 0)]
      (= [:exoscale.ex/forbidden "token validity expired"]
-        (-> (try
-              (danger/verify (-> input
-                                 (dissoc ::danger/payload)
-                                 (assoc ::danger/token token)
-                                 (assoc ::danger/max-age 86400)))
-              (catch Exception e
-                [(:type (ex-data e)) (ex-message e)])))))))
+        (try
+          (danger/verify config token 86400)
+          (catch Exception e
+            [(:type (ex-data e)) (ex-message e)]))))))
 
 (defspec token-validity-is-enforced-small-window
   10000
   (prop/for-all
-   [input (s/gen (s/keys :req [::danger/algorithm ::danger/payload
-                               ::danger/private-key ::danger/salt]))]
-   (let [token (danger/sign
-                (-> input
-                    (assoc ::danger/timestamp (dec (danger/epoch)))))]
+   [config  (s/gen ::danger/config)
+    payload (s/gen ::danger/payload)]
+   (let [token (danger/sign config payload (dec (danger/epoch)))]
      (= [:exoscale.ex/forbidden "token validity expired"]
-        (-> (try
-              (danger/verify (-> input
-                                 (dissoc ::danger/payload)
-                                 (assoc ::danger/token token)
-                                 (assoc ::danger/max-age 0)))
-              (catch Exception e
-                [(:type (ex-data e)) (ex-message e)])))))))
+        (try
+          (danger/verify config token 0)
+          (catch Exception e
+            [(:type (ex-data e)) (ex-message e)]))))))
 
 (defspec token-signature-is-enforced-private-key-variant
   10000
   (prop/for-all
-   [input (s/gen (s/keys :req [::danger/algorithm ::danger/payload
-                               ::danger/private-key ::danger/salt]))]
-   (let [token (danger/sign input)]
+   [base        (s/gen ::danger/config)
+    private-key (s/gen ::danger/private-key)
+    payload     (s/gen ::danger/payload)]
+   (let [good-config (assoc base ::danger/private-keys [private-key])
+         bad-config  (assoc base ::danger/private-keys [(str private-key "f")])
+         token       (danger/sign good-config payload)]
      (= [:exoscale.ex/forbidden "invalid signature"]
-        (-> (try
-              (danger/verify (-> input
-                                 (dissoc ::danger/payload)
-                                 (assoc ::danger/token token)
-                                 (update ::danger/private-key str "suffix")))
-              (catch Exception e
-                [(:type (ex-data e)) (ex-message e)])))))))
+        (try
+          (danger/verify  bad-config token)
+          (catch Exception e
+            [(:type (ex-data e)) (ex-message e)]))))))
 
 (defspec token-signature-is-enforced-salt-variant
   10000
   (prop/for-all
-   [input (s/gen (s/keys :req [::danger/algorithm ::danger/payload
-                               ::danger/private-key ::danger/salt]))]
-   (let [token (danger/sign input)]
+   [config  (s/gen ::danger/config)
+    payload (s/gen ::danger/payload)]
+   (let [token (danger/sign config payload)]
      (= [:exoscale.ex/forbidden "invalid signature"]
-        (-> (try
-              (danger/verify (-> input
-                                 (dissoc ::danger/payload)
-                                 (assoc ::danger/token token)
-                                 (update ::danger/salt str "suffix")))
-              (catch Exception e
-                [(:type (ex-data e)) (ex-message e)])))))))
+        (try
+          (danger/verify (update config ::danger/salt str "suffix") token)
+          (catch Exception e
+            [(:type (ex-data e)) (ex-message e)]))))))

--- a/test/exoscale/itsdangerous_test.clj
+++ b/test/exoscale/itsdangerous_test.clj
@@ -21,6 +21,26 @@
                              :exoscale.itsdangerous/token       token})
              payload)))))
 
+(deftest multiple-key-test
+  ;; Replicate usage shown in the README
+  (let [payload      "{\"user-id\": 1234}"
+        old-key      "A-SECRET-KEY"
+        private-keys ["ANOTHER-KEY" old-key]
+        salt         "session"
+        algorithm    ::danger/hmac-sha1
+        token        (danger/sign {:exoscale.itsdangerous/algorithm   algorithm
+                                   :exoscale.itsdangerous/private-key old-key
+                                   :exoscale.itsdangerous/salt        salt
+                                   :exoscale.itsdangerous/payload     payload})]
+
+    (testing "Verifying yields the initial payload"
+
+      (is (= (danger/verify {:exoscale.itsdangerous/algorithm    algorithm
+                             :exoscale.itsdangerous/private-keys private-keys
+                             :exoscale.itsdangerous/salt         salt
+                             :exoscale.itsdangerous/token        token})
+             payload)))))
+
 (deftest compatibility-test
   (is (= (danger/verify {::danger/algorithm   ::danger/hmac-sha1
                          ::danger/private-key "A-SECRET-KEY"


### PR DESCRIPTION
To allow key rotation over time, introduce a new config key
`::private-keys`, a collection of keys to try building signatures
with.

The first key in the collection is always selected for signing,
but verifying tries all keys, this allows adding keys over time.

`sign` and `verify` now allow additional arities for the payload
and timestamp (or max-age).